### PR TITLE
Extract bottom sheet to separate component

### DIFF
--- a/module/files/file-explorer/src/androidMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
+++ b/module/files/file-explorer/src/androidMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
@@ -5,6 +5,7 @@ import ru.bartwell.kick.core.data.PlatformContext
 import ru.bartwell.kick.core.data.get
 import ru.bartwell.kick.module.explorer.feature.list.data.FileEntry
 import java.io.File
+import java.io.IOException
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 internal actual object FileSystemUtils {
@@ -38,5 +39,20 @@ internal actual object FileSystemUtils {
 
     actual fun getParentPath(path: String): String? {
         return File(path).parent
+    }
+
+    actual fun readFileText(path: String): String = File(path).readText()
+
+    actual fun exportFile(context: PlatformContext, path: String): String? {
+        val src = File(path)
+        val destDir = context.get().getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+            ?: context.get().filesDir
+        val dest = File(destDir, src.name)
+        return try {
+            src.copyTo(dest, overwrite = true)
+            dest.absolutePath
+        } catch (_: IOException) {
+            null
+        }
     }
 }

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/FileExplorerModule.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/FileExplorerModule.kt
@@ -6,15 +6,24 @@ import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.pop
+import com.arkivanov.decompose.router.stack.pushNew
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import ru.bartwell.kick.core.component.Child
 import ru.bartwell.kick.core.component.Config
 import ru.bartwell.kick.core.data.Module
 import ru.bartwell.kick.core.data.ModuleDescription
 import ru.bartwell.kick.module.explorer.core.component.child.FileExplorerChild
+import ru.bartwell.kick.module.explorer.core.component.child.FileViewerChild
+import ru.bartwell.kick.module.explorer.core.component.child.FileOptionsChild
 import ru.bartwell.kick.module.explorer.core.component.config.FileExplorerConfig
+import ru.bartwell.kick.module.explorer.core.component.config.FileViewerConfig
+import ru.bartwell.kick.module.explorer.core.component.config.FileOptionsConfig
 import ru.bartwell.kick.module.explorer.feature.list.presentation.DefaultFileExplorerComponent
 import ru.bartwell.kick.module.explorer.feature.list.presentation.FileExplorerContent
+import ru.bartwell.kick.module.explorer.feature.options.presentation.DefaultFileOptionsComponent
+import ru.bartwell.kick.module.explorer.feature.options.presentation.FileOptionsContent
+import ru.bartwell.kick.module.explorer.feature.viewer.presentation.DefaultFileViewerComponent
+import ru.bartwell.kick.module.explorer.feature.viewer.presentation.FileViewerContent
 
 public class FileExplorerModule : Module {
     override val description: ModuleDescription = ModuleDescription.FILE_EXPLORER
@@ -24,25 +33,45 @@ public class FileExplorerModule : Module {
         componentContext: ComponentContext,
         nav: StackNavigation<Config>,
         config: Config
-    ): Child<*>? = if (config is FileExplorerConfig) {
-        FileExplorerChild(
+    ): Child<*>? = when (config) {
+        is FileExplorerConfig -> FileExplorerChild(
             DefaultFileExplorerComponent(
                 componentContext = componentContext,
+                onFinished = { nav.pop() },
+                onViewFile = { path -> nav.pushNew(FileViewerConfig(path)) },
+                onShowOptions = { path -> nav.pushNew(FileOptionsConfig(path)) }
+            )
+        )
+        is FileViewerConfig -> FileViewerChild(
+            DefaultFileViewerComponent(
+                componentContext = componentContext,
+                filePath = config.path,
                 onFinished = { nav.pop() }
             )
         )
-    } else {
-        null
+        is FileOptionsConfig -> FileOptionsChild(
+            DefaultFileOptionsComponent(
+                componentContext = componentContext,
+                filePath = config.path,
+                onViewFile = { path -> nav.pushNew(FileViewerConfig(path)) },
+                onFinished = { nav.pop() }
+            )
+        )
+        else -> null
     }
 
     @Composable
     override fun Content(instance: Child<*>) {
         when (val child = instance) {
             is FileExplorerChild -> FileExplorerContent(modifier = Modifier.fillMaxSize(), component = child.component)
+            is FileViewerChild -> FileViewerContent(modifier = Modifier.fillMaxSize(), component = child.component)
+            is FileOptionsChild -> FileOptionsContent(component = child.component)
         }
     }
 
     override fun registerSubclasses(builder: PolymorphicModuleBuilder<Config>) {
         builder.subclass(FileExplorerConfig::class, FileExplorerConfig.serializer())
+        builder.subclass(FileViewerConfig::class, FileViewerConfig.serializer())
+        builder.subclass(FileOptionsConfig::class, FileOptionsConfig.serializer())
     }
 }

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/child/FileOptionsChild.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/child/FileOptionsChild.kt
@@ -1,0 +1,8 @@
+package ru.bartwell.kick.module.explorer.core.component.child
+
+import ru.bartwell.kick.core.component.Child
+import ru.bartwell.kick.module.explorer.feature.options.presentation.FileOptionsComponent
+
+internal data class FileOptionsChild(
+    override val component: FileOptionsComponent,
+) : Child<FileOptionsComponent>

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/child/FileViewerChild.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/child/FileViewerChild.kt
@@ -1,0 +1,6 @@
+package ru.bartwell.kick.module.explorer.core.component.child
+
+import ru.bartwell.kick.core.component.Child
+import ru.bartwell.kick.module.explorer.feature.viewer.presentation.FileViewerComponent
+
+internal class FileViewerChild(override val component: FileViewerComponent) : Child<FileViewerComponent>

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/config/FileOptionsConfig.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/config/FileOptionsConfig.kt
@@ -1,0 +1,9 @@
+package ru.bartwell.kick.module.explorer.core.component.config
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import ru.bartwell.kick.core.component.Config
+
+@Serializable
+@SerialName("FileOptionsConfig")
+internal data class FileOptionsConfig(val path: String) : Config

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/config/FileViewerConfig.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/config/FileViewerConfig.kt
@@ -1,0 +1,9 @@
+package ru.bartwell.kick.module.explorer.core.component.config
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import ru.bartwell.kick.core.component.Config
+
+@Serializable
+@SerialName("FileViewerConfig")
+internal data class FileViewerConfig(val path: String) : Config

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/DefaultFileExplorerComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/DefaultFileExplorerComponent.kt
@@ -8,7 +8,9 @@ import ru.bartwell.kick.module.explorer.feature.list.util.FileSystemUtils
 
 internal class DefaultFileExplorerComponent(
     componentContext: ComponentContext,
-    private val onFinished: () -> Unit
+    private val onFinished: () -> Unit,
+    private val onViewFile: (String) -> Unit,
+    private val onShowOptions: (String) -> Unit,
 ) : FileExplorerComponent, ComponentContext by componentContext {
 
     private val _model = MutableValue(FileExplorerState())
@@ -39,6 +41,19 @@ internal class DefaultFileExplorerComponent(
             "$current/$name"
         }
         loadDirectory(path)
+    }
+
+    private fun buildFilePath(name: String): String {
+        val current = model.value.currentPath
+        return if (current.endsWith("/")) {
+            current + name
+        } else {
+            "$current/$name"
+        }
+    }
+
+    override fun onFileClick(name: String) {
+        onShowOptions(buildFilePath(name))
     }
 
     override fun onKnownFolderClick(path: String) {

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/FileExplorerComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/FileExplorerComponent.kt
@@ -9,6 +9,7 @@ internal interface FileExplorerComponent : Component {
     fun init(context: PlatformContext)
     fun onUpClick()
     fun onDirectoryClick(name: String)
+    fun onFileClick(name: String)
     fun onKnownFolderClick(path: String)
     fun onBackClick()
 }

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/FileExplorerContent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/FileExplorerContent.kt
@@ -88,6 +88,7 @@ internal fun FileExplorerContent(
                 )
             }
         }
+
     }
 }
 
@@ -134,6 +135,8 @@ private fun ColumnScope.EntriesList(
                 modifier = Modifier.clickable {
                     if (entry.isDirectory) {
                         component.onDirectoryClick(entry.name)
+                    } else {
+                        component.onFileClick(entry.name)
                     }
                 },
                 headlineContent = { Text(entry.name) },

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
@@ -9,6 +9,12 @@ internal expect object FileSystemUtils {
     fun listDirectory(path: String): List<FileEntry>
     fun getKnownFolders(context: PlatformContext): List<KnownFolder>
     fun getParentPath(path: String): String?
+    fun readFileText(path: String): String
+    /**
+     * Copies the file located at [path] to a user-accessible directory and
+     * returns absolute destination path if the operation was successful.
+     */
+    fun exportFile(context: PlatformContext, path: String): String?
 }
 
 internal data class KnownFolder(val name: String, val path: String)

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/DefaultFileOptionsComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/DefaultFileOptionsComponent.kt
@@ -1,0 +1,39 @@
+package ru.bartwell.kick.module.explorer.feature.options.presentation
+
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import ru.bartwell.kick.core.data.PlatformContext
+import ru.bartwell.kick.module.explorer.feature.list.util.FileSystemUtils
+
+internal class DefaultFileOptionsComponent(
+    componentContext: ComponentContext,
+    private val filePath: String,
+    private val onViewFile: (String) -> Unit,
+    private val onFinished: () -> Unit,
+) : FileOptionsComponent, ComponentContext by componentContext {
+
+    private val _model = MutableValue(FileOptionsState())
+    override val model: Value<FileOptionsState> = _model
+
+    override fun onDismiss() {
+        onFinished()
+    }
+
+    override fun onViewAsText() {
+        onFinished()
+        onViewFile(filePath)
+    }
+
+    override fun onDownload(context: PlatformContext) {
+        val exported = FileSystemUtils.exportFile(context, filePath)
+        _model.value = FileOptionsState(
+            isSheetVisible = false,
+            alertMessage = exported?.let { "Saved to $it" }
+        )
+    }
+
+    override fun onAlertDismiss() {
+        onFinished()
+    }
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/FileOptionsComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/FileOptionsComponent.kt
@@ -1,0 +1,13 @@
+package ru.bartwell.kick.module.explorer.feature.options.presentation
+
+import com.arkivanov.decompose.value.Value
+import ru.bartwell.kick.core.component.Component
+import ru.bartwell.kick.core.data.PlatformContext
+
+internal interface FileOptionsComponent : Component {
+    val model: Value<FileOptionsState>
+    fun onDismiss()
+    fun onViewAsText()
+    fun onDownload(context: PlatformContext)
+    fun onAlertDismiss()
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/FileOptionsContent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/FileOptionsContent.kt
@@ -1,0 +1,50 @@
+package ru.bartwell.kick.module.explorer.feature.options.presentation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.ui.Modifier
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import ru.bartwell.kick.core.data.platformContext
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FileOptionsContent(component: FileOptionsComponent) {
+    val state by component.model.subscribeAsState()
+    val context = platformContext()
+
+    if (state.isSheetVisible) {
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ModalBottomSheet(
+            onDismissRequest = component::onDismiss,
+            sheetState = sheetState
+        ) {
+            ListItem(
+                modifier = Modifier.clickable { component.onDownload(context) },
+                headlineContent = { Text("Download") }
+            )
+            ListItem(
+                modifier = Modifier.clickable(component::onViewAsText),
+                headlineContent = { Text("View as text") }
+            )
+        }
+    }
+
+    state.alertMessage?.let { message ->
+        AlertDialog(
+            onDismissRequest = component::onAlertDismiss,
+            confirmButton = {
+                TextButton(onClick = component::onAlertDismiss) { Text("OK") }
+            },
+            title = { Text("Export complete") },
+            text = { Text(message) }
+        )
+    }
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/FileOptionsContent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/FileOptionsContent.kt
@@ -31,7 +31,7 @@ internal fun FileOptionsContent(component: FileOptionsComponent) {
                 headlineContent = { Text("Download") }
             )
             ListItem(
-                modifier = Modifier.clickable(component::onViewAsText),
+                modifier = Modifier.clickable(onClick = component::onViewAsText),
                 headlineContent = { Text("View as text") }
             )
         }

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/FileOptionsState.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/options/presentation/FileOptionsState.kt
@@ -1,0 +1,6 @@
+package ru.bartwell.kick.module.explorer.feature.options.presentation
+
+internal data class FileOptionsState(
+    val isSheetVisible: Boolean = true,
+    val alertMessage: String? = null,
+)

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/viewer/presentation/DefaultFileViewerComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/viewer/presentation/DefaultFileViewerComponent.kt
@@ -1,0 +1,29 @@
+package ru.bartwell.kick.module.explorer.feature.viewer.presentation
+
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import ru.bartwell.kick.module.explorer.feature.list.util.FileSystemUtils
+import java.io.File
+
+internal class DefaultFileViewerComponent(
+    componentContext: ComponentContext,
+    private val filePath: String,
+    private val onFinished: () -> Unit,
+) : FileViewerComponent, ComponentContext by componentContext {
+
+    private val _model = MutableValue(FileViewerState())
+    override val model: Value<FileViewerState> = _model
+
+    init {
+        loadData()
+    }
+
+    private fun loadData() {
+        val text = FileSystemUtils.readFileText(filePath)
+        val name = File(filePath).name
+        _model.value = FileViewerState(fileName = name, text = text)
+    }
+
+    override fun onBackPressed() = onFinished()
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/viewer/presentation/FileViewerComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/viewer/presentation/FileViewerComponent.kt
@@ -1,0 +1,9 @@
+package ru.bartwell.kick.module.explorer.feature.viewer.presentation
+
+import com.arkivanov.decompose.value.Value
+import ru.bartwell.kick.core.component.Component
+
+internal interface FileViewerComponent : Component {
+    val model: Value<FileViewerState>
+    fun onBackPressed()
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/viewer/presentation/FileViewerContent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/viewer/presentation/FileViewerContent.kt
@@ -1,0 +1,44 @@
+package ru.bartwell.kick.module.explorer.feature.viewer.presentation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FileViewerContent(component: FileViewerComponent, modifier: Modifier = Modifier) {
+    val state by component.model.subscribeAsState()
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text(state.fileName) },
+            navigationIcon = {
+                IconButton(onClick = component::onBackPressed) {
+                    Icon(imageVector = Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back")
+                }
+            }
+        )
+        val scrollState = rememberScrollState()
+        Text(
+            text = state.text,
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(16.dp)
+        )
+    }
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/viewer/presentation/FileViewerState.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/viewer/presentation/FileViewerState.kt
@@ -1,0 +1,6 @@
+package ru.bartwell.kick.module.explorer.feature.viewer.presentation
+
+internal data class FileViewerState(
+    val fileName: String = "",
+    val text: String = "",
+)

--- a/module/files/file-explorer/src/iosMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
+++ b/module/files/file-explorer/src/iosMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
@@ -4,9 +4,11 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSApplicationSupportDirectory
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSDate
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSDirectoryEnumerationSkipsHiddenFiles
 import platform.Foundation.NSDocumentDirectory
-import platform.Foundation.NSFileManager
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.NSNumber
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSTemporaryDirectory
@@ -105,4 +107,18 @@ internal actual object FileSystemUtils {
         NSURL.fileURLWithPath(path)
             .URLByDeletingLastPathComponent
             ?.path
+
+    actual fun readFileText(path: String): String =
+        NSString.stringWithContentsOfFile(path, NSUTF8StringEncoding, null) ?: ""
+
+    actual fun exportFile(context: PlatformContext, path: String): String? {
+        val docsDir = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true)
+            .firstOrNull() as? String ?: return null
+        val destPath = "$docsDir/${path.substringAfterLast('/')}"
+        return if (NSFileManager.defaultManager.copyItemAtPath(path, destPath, null)) {
+            destPath
+        } else {
+            null
+        }
+    }
 }

--- a/module/files/file-explorer/src/jvmMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
+++ b/module/files/file-explorer/src/jvmMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
@@ -3,6 +3,7 @@ package ru.bartwell.kick.module.explorer.feature.list.util
 import ru.bartwell.kick.core.data.PlatformContext
 import ru.bartwell.kick.module.explorer.feature.list.data.FileEntry
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -59,5 +60,18 @@ internal actual object FileSystemUtils {
 
     actual fun getParentPath(path: String): String? {
         return File(path).parent
+    }
+
+    actual fun readFileText(path: String): String = File(path).readText()
+
+    actual fun exportFile(context: PlatformContext, path: String): String? {
+        val src = File(path)
+        val dest = Paths.get(System.getProperty("user.home"), "Downloads", src.name).toFile()
+        return try {
+            src.copyTo(dest, overwrite = true)
+            dest.absolutePath
+        } catch (_: IOException) {
+            null
+        }
     }
 }


### PR DESCRIPTION
## Summary
- refactor file explorer state and component interface
- create FileOptions component, config, child, and composable
- open file options via navigation
- register FileOptions in module navigation

## Testing
- `./gradlew :file-explorer:tasks --all`
- `./gradlew :file-explorer:build`

------
https://chatgpt.com/codex/tasks/task_e_6886313f54848326aba0be5c96f34655