### PR TITLE
Enhance file explorer

### DIFF
--- a/module/files/file-explorer/src/androidMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
+++ b/module/files/file-explorer/src/androidMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
@@ -4,6 +4,7 @@ import android.os.Environment
 import ru.bartwell.kick.core.data.PlatformContext
 import ru.bartwell.kick.core.data.get
 import ru.bartwell.kick.module.explorer.feature.list.data.FileEntry
+import ru.bartwell.kick.module.explorer.feature.list.data.Result
 import java.io.File
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
@@ -38,5 +39,19 @@ internal actual object FileSystemUtils {
 
     actual fun getParentPath(path: String): String? {
         return File(path).parent
+    }
+
+    actual fun readText(path: String): Result = Result.Success(File(path).readText())
+
+    actual fun exportFile(context: PlatformContext, path: String): Result {
+        val destinationDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        val destination = File(destinationDir, File(path).name)
+        @Suppress("TooGenericExceptionCaught")
+        return try {
+            File(path).copyTo(destination, overwrite = true)
+            Result.Success(destination.absolutePath)
+        } catch (e: Exception) {
+            Result.Error(e.message ?: "Unknown error")
+        }
     }
 }

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/FileExplorerModule.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/FileExplorerModule.kt
@@ -6,15 +6,20 @@ import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.pop
+import com.arkivanov.decompose.router.stack.pushNew
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import ru.bartwell.kick.core.component.Child
 import ru.bartwell.kick.core.component.Config
 import ru.bartwell.kick.core.data.Module
 import ru.bartwell.kick.core.data.ModuleDescription
 import ru.bartwell.kick.module.explorer.core.component.child.FileExplorerChild
+import ru.bartwell.kick.module.explorer.core.component.child.FileViewerChild
 import ru.bartwell.kick.module.explorer.core.component.config.FileExplorerConfig
+import ru.bartwell.kick.module.explorer.core.component.config.FileViewerConfig
 import ru.bartwell.kick.module.explorer.feature.list.presentation.DefaultFileExplorerComponent
 import ru.bartwell.kick.module.explorer.feature.list.presentation.FileExplorerContent
+import ru.bartwell.kick.module.explorer.feature.view.presentation.DefaultFileViewerComponent
+import ru.bartwell.kick.module.explorer.feature.view.presentation.FileViewerContent
 
 public class FileExplorerModule : Module {
     override val description: ModuleDescription = ModuleDescription.FILE_EXPLORER
@@ -24,25 +29,34 @@ public class FileExplorerModule : Module {
         componentContext: ComponentContext,
         nav: StackNavigation<Config>,
         config: Config
-    ): Child<*>? = if (config is FileExplorerConfig) {
-        FileExplorerChild(
+    ): Child<*>? = when (config) {
+        is FileExplorerConfig -> FileExplorerChild(
             DefaultFileExplorerComponent(
                 componentContext = componentContext,
+                onFinished = { nav.pop() },
+                onFileOpen = { path -> nav.pushNew(FileViewerConfig(path)) }
+            )
+        )
+        is FileViewerConfig -> FileViewerChild(
+            DefaultFileViewerComponent(
+                componentContext = componentContext,
+                path = config.path,
                 onFinished = { nav.pop() }
             )
         )
-    } else {
-        null
+        else -> null
     }
 
     @Composable
     override fun Content(instance: Child<*>) {
         when (val child = instance) {
             is FileExplorerChild -> FileExplorerContent(modifier = Modifier.fillMaxSize(), component = child.component)
+            is FileViewerChild -> FileViewerContent(modifier = Modifier.fillMaxSize(), component = child.component)
         }
     }
 
     override fun registerSubclasses(builder: PolymorphicModuleBuilder<Config>) {
         builder.subclass(FileExplorerConfig::class, FileExplorerConfig.serializer())
+        builder.subclass(FileViewerConfig::class, FileViewerConfig.serializer())
     }
 }

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/child/FileViewerChild.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/child/FileViewerChild.kt
@@ -1,0 +1,6 @@
+package ru.bartwell.kick.module.explorer.core.component.child
+
+import ru.bartwell.kick.core.component.Child
+import ru.bartwell.kick.module.explorer.feature.view.presentation.FileViewerComponent
+
+internal class FileViewerChild(override val component: FileViewerComponent) : Child<FileViewerComponent>

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/config/FileViewerConfig.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/core/component/config/FileViewerConfig.kt
@@ -1,0 +1,9 @@
+package ru.bartwell.kick.module.explorer.core.component.config
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import ru.bartwell.kick.core.component.Config
+
+@Serializable
+@SerialName("FileViewerConfig")
+internal data class FileViewerConfig(val path: String) : Config

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/data/Result.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/data/Result.kt
@@ -1,0 +1,6 @@
+package ru.bartwell.kick.module.explorer.feature.list.data
+
+internal sealed class Result {
+    data class Success(val data: String) : Result()
+    data class Error(val message: String) : Result()
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/DefaultFileExplorerComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/DefaultFileExplorerComponent.kt
@@ -4,11 +4,13 @@ import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import ru.bartwell.kick.core.data.PlatformContext
+import ru.bartwell.kick.module.explorer.feature.list.data.Result
 import ru.bartwell.kick.module.explorer.feature.list.util.FileSystemUtils
 
 internal class DefaultFileExplorerComponent(
     componentContext: ComponentContext,
-    private val onFinished: () -> Unit
+    private val onFinished: () -> Unit,
+    private val onFileOpen: (String) -> Unit
 ) : FileExplorerComponent, ComponentContext by componentContext {
 
     private val _model = MutableValue(FileExplorerState())
@@ -22,6 +24,15 @@ internal class DefaultFileExplorerComponent(
         val entries = FileSystemUtils.listDirectory(path)
         val canGoUp = FileSystemUtils.getParentPath(path) != null
         _model.value = model.value.copy(currentPath = path, entries = entries, canGoUp = canGoUp)
+    }
+
+    private fun fullPath(name: String): String {
+        val current = model.value.currentPath
+        return if (current.endsWith("/")) {
+            current + name
+        } else {
+            "$current/$name"
+        }
     }
 
     override fun onUpClick() {
@@ -41,8 +52,41 @@ internal class DefaultFileExplorerComponent(
         loadDirectory(path)
     }
 
+    override fun onFileClick(name: String) {
+        _model.value = model.value.copy(selectedFileName = name)
+    }
+
+    override fun onFileActionDismiss() {
+        _model.value = model.value.copy(selectedFileName = null)
+    }
+
+    override fun onViewAsTextClick() {
+        val fileName = model.value.selectedFileName ?: return
+        _model.value = model.value.copy(selectedFileName = null)
+        onFileOpen(fullPath(fileName))
+    }
+
+    override fun onDownloadClick(context: PlatformContext) {
+        val fileName = model.value.selectedFileName ?: return
+        _model.value = model.value.copy(selectedFileName = null)
+        val path = fullPath(fileName)
+        val result = FileSystemUtils.exportFile(context, path)
+        when (result) {
+            is Result.Success -> _model.value = model.value.copy(exportedFilePath = result.data)
+            is Result.Error -> _model.value = model.value.copy(error = result.message)
+        }
+    }
+
+    override fun onExportAlertDismiss() {
+        _model.value = model.value.copy(exportedFilePath = null)
+    }
+
     override fun onKnownFolderClick(path: String) {
         loadDirectory(path)
+    }
+
+    override fun onErrorAlertDismiss() {
+        _model.value = model.value.copy(error = null)
     }
 
     override fun onBackClick() {

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/FileExplorerComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/FileExplorerComponent.kt
@@ -4,11 +4,18 @@ import com.arkivanov.decompose.value.Value
 import ru.bartwell.kick.core.component.Component
 import ru.bartwell.kick.core.data.PlatformContext
 
+@Suppress("TooManyFunctions")
 internal interface FileExplorerComponent : Component {
     val model: Value<FileExplorerState>
     fun init(context: PlatformContext)
     fun onUpClick()
     fun onDirectoryClick(name: String)
+    fun onFileClick(name: String)
+    fun onFileActionDismiss()
+    fun onViewAsTextClick()
+    fun onDownloadClick(context: PlatformContext)
+    fun onExportAlertDismiss()
     fun onKnownFolderClick(path: String)
+    fun onErrorAlertDismiss()
     fun onBackClick()
 }

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/FileExplorerState.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/presentation/FileExplorerState.kt
@@ -6,6 +6,9 @@ internal data class FileExplorerState(
     val currentPath: String = "",
     val entries: List<FileEntry> = emptyList(),
     val canGoUp: Boolean = true,
+    val selectedFileName: String? = null,
+    val exportedFilePath: String? = null,
+    val error: String? = null,
 ) {
     val folderName: String
         get() = currentPath.substringAfterLast('/', currentPath)

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/list/util/FileSystemUtils.kt
@@ -2,6 +2,7 @@ package ru.bartwell.kick.module.explorer.feature.list.util
 
 import ru.bartwell.kick.core.data.PlatformContext
 import ru.bartwell.kick.module.explorer.feature.list.data.FileEntry
+import ru.bartwell.kick.module.explorer.feature.list.data.Result
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 internal expect object FileSystemUtils {
@@ -9,6 +10,8 @@ internal expect object FileSystemUtils {
     fun listDirectory(path: String): List<FileEntry>
     fun getKnownFolders(context: PlatformContext): List<KnownFolder>
     fun getParentPath(path: String): String?
+    fun readText(path: String): Result
+    fun exportFile(context: PlatformContext, path: String): Result
 }
 
 internal data class KnownFolder(val name: String, val path: String)

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/view/presentation/DefaultFileViewerComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/view/presentation/DefaultFileViewerComponent.kt
@@ -1,0 +1,37 @@
+package ru.bartwell.kick.module.explorer.feature.view.presentation
+
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import ru.bartwell.kick.core.data.PlatformContext
+import ru.bartwell.kick.module.explorer.feature.list.data.Result
+import ru.bartwell.kick.module.explorer.feature.list.util.FileSystemUtils
+
+internal class DefaultFileViewerComponent(
+    componentContext: ComponentContext,
+    private val path: String,
+    private val onFinished: () -> Unit
+) : FileViewerComponent, ComponentContext by componentContext {
+
+    private val _model = MutableValue(FileViewerState())
+    override val model: Value<FileViewerState> = _model
+
+    override fun init(context: PlatformContext) {
+        val result = FileSystemUtils.readText(path)
+        when (result) {
+            is Result.Success -> _model.value = model.value.copy(
+                fileName = path.substringAfterLast('/'),
+                text = result.data,
+            )
+
+            is Result.Error -> _model.value = model.value.copy(error = result.message)
+        }
+    }
+
+    override fun onBackClick() = onFinished()
+
+    override fun onErrorAlertDismiss() {
+        _model.value = model.value.copy(error = null)
+        onFinished()
+    }
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/view/presentation/FileViewerComponent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/view/presentation/FileViewerComponent.kt
@@ -1,0 +1,12 @@
+package ru.bartwell.kick.module.explorer.feature.view.presentation
+
+import com.arkivanov.decompose.value.Value
+import ru.bartwell.kick.core.component.Component
+import ru.bartwell.kick.core.data.PlatformContext
+
+internal interface FileViewerComponent : Component {
+    val model: Value<FileViewerState>
+    fun init(context: PlatformContext)
+    fun onBackClick()
+    fun onErrorAlertDismiss()
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/view/presentation/FileViewerContent.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/view/presentation/FileViewerContent.kt
@@ -1,0 +1,52 @@
+package ru.bartwell.kick.module.explorer.feature.view.presentation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import ru.bartwell.kick.core.data.platformContext
+import ru.bartwell.kick.core.presentation.ErrorAlert
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FileViewerContent(component: FileViewerComponent, modifier: Modifier = Modifier) {
+    val state by component.model.subscribeAsState()
+    val context = platformContext()
+    LaunchedEffect(Unit) { component.init(context) }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text(state.fileName) },
+            navigationIcon = {
+                IconButton(onClick = component::onBackClick) {
+                    Icon(imageVector = Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
+                }
+            }
+        )
+        Text(
+            text = state.text,
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+        )
+    }
+
+    state.error?.let { error ->
+        ErrorAlert(message = error, onDismiss = component::onErrorAlertDismiss)
+    }
+}

--- a/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/view/presentation/FileViewerState.kt
+++ b/module/files/file-explorer/src/commonMain/kotlin/ru/bartwell/kick/module/explorer/feature/view/presentation/FileViewerState.kt
@@ -1,0 +1,7 @@
+package ru.bartwell.kick.module.explorer.feature.view.presentation
+
+internal data class FileViewerState(
+    val fileName: String = "",
+    val text: String = "",
+    val error: String? = null,
+)


### PR DESCRIPTION
This commit introduces the ability to interact with files within the file explorer.

Key changes include:
- **File Viewer:** Implemented a new screen to display the content of text files.
- **File Export/Download:**
  - Implemented `exportFile` functionality in `FileSystemUtils` for Android, iOS, and JVM.
  - On Android, files are saved to the public "Downloads" directory.
  - On iOS, files are saved to the app's "Documents" directory.
  - On JVM, a save file dialog is shown.