### PR TITLE
feat: show module descriptions

### DIFF
--- a/main-core/src/commonMain/kotlin/ru/bartwell/kick/core/data/ModuleDescription.kt
+++ b/main-core/src/commonMain/kotlin/ru/bartwell/kick/core/data/ModuleDescription.kt
@@ -1,13 +1,37 @@
 package ru.bartwell.kick.core.data
 
-public enum class ModuleDescription(public val title: String) {
-    SQL_DELIGHT(title = "SQLDelight"),
-    ROOM(title = "Room"),
-    LOGGING(title = "Logging"),
-    KTOR3(title = "Ktor3"),
-    CONFIGURATION(title = "Configuration"),
-    MULTIPLATFORM_SETTINGS(title = "Settings"),
-    FILE_EXPLORER(title = "File Explorer"),
+public enum class ModuleDescription(
+    public val title: String,
+    public val description: String,
+) {
+    SQL_DELIGHT(
+        title = "SQLDelight",
+        description = "Use to check storage layer powered by SQLDelight.",
+    ),
+    ROOM(
+        title = "Room",
+        description = "Use to check storage layer built on Room.",
+    ),
+    LOGGING(
+        title = "Logging",
+        description = "Shows log output to help track issues during tests.",
+    ),
+    KTOR3(
+        title = "Ktor3",
+        description = "Executes HTTP requests with Ktor 3 for server communication tests.",
+    ),
+    CONFIGURATION(
+        title = "Configuration",
+        description = "Edit app configuration values to simulate different scenarios.",
+    ),
+    MULTIPLATFORM_SETTINGS(
+        title = "Settings",
+        description = "Manage key-value preferences to verify behaviour.",
+    ),
+    FILE_EXPLORER(
+        title = "File Explorer",
+        description = "Browse device files to confirm saved data.",
+    ),
     LAYOUT(title = "Layout"),
     OVERLAY(title = "Overlay"),
 }

--- a/main-core/src/commonMain/kotlin/ru/bartwell/kick/core/data/ModuleDescription.kt
+++ b/main-core/src/commonMain/kotlin/ru/bartwell/kick/core/data/ModuleDescription.kt
@@ -6,31 +6,31 @@ public enum class ModuleDescription(
 ) {
     SQL_DELIGHT(
         title = "SQLDelight",
-        description = "Use to check storage layer powered by SQLDelight.",
+        description = "View and edit the app’s SQLDelight database: browse tables, change values, verify UI."
     ),
     ROOM(
         title = "Room",
-        description = "Use to check storage layer built on Room.",
+        description = "Inspect the Room database: browse tables, update fields, and confirm UI reflects changes."
     ),
     LOGGING(
         title = "Logging",
-        description = "Shows log output to help track issues during tests.",
+        description = "Live log viewer: watch actions/errors in real time, filter, and share when reproducing bugs."
     ),
     KTOR3(
         title = "Ktor3",
-        description = "Executes HTTP requests with Ktor 3 for server communication tests.",
+        description = "Network monitor: see requests/responses (URL, status, body) and find where a call fails."
     ),
     CONFIGURATION(
         title = "Configuration",
-        description = "Edit app configuration values to simulate different scenarios.",
+        description = "Toggle features and options on the fly; switch endpoints, tweak limits, reset to defaults."
     ),
     MULTIPLATFORM_SETTINGS(
         title = "Settings",
-        description = "Manage key-value preferences to verify behaviour.",
+        description = "Edit app preferences (key–value): test flags, tokens, and options with quick text changes."
     ),
     FILE_EXPLORER(
         title = "File Explorer",
-        description = "Browse device files to confirm saved data.",
+        description = "Browse app files—caches, logs, databases. Open, share, or delete to simulate scenarios."
     ),
     LAYOUT(title = "Layout"),
     OVERLAY(title = "Overlay"),

--- a/main-core/src/commonMain/kotlin/ru/bartwell/kick/core/data/ModuleDescription.kt
+++ b/main-core/src/commonMain/kotlin/ru/bartwell/kick/core/data/ModuleDescription.kt
@@ -32,6 +32,12 @@ public enum class ModuleDescription(
         title = "File Explorer",
         description = "Browse app files—caches, logs, databases. Open, share, or delete to simulate scenarios."
     ),
-    LAYOUT(title = "Layout"),
-    OVERLAY(title = "Overlay"),
+    LAYOUT(
+        title = "Layout",
+        description = "Inspect the current screen’s UI tree: view hierarchy and key layout properties."
+    ),
+    OVERLAY(
+        title = "Overlay",
+        description = "Floating debug panel over the app that updates in real time. Shows live key/value metrics."
+    ),
 }

--- a/main-runtime/src/commonMain/kotlin/ru/bartwell/kick/runtime/feature/list/presentation/ModulesListContent.kt
+++ b/main-runtime/src/commonMain/kotlin/ru/bartwell/kick/runtime/feature/list/presentation/ModulesListContent.kt
@@ -78,6 +78,7 @@ private fun Item(module: ModuleInfo, onClick: () -> Unit) {
     ListItem(
         modifier = Modifier.clickable(onClick = onClick),
         headlineContent = { Text(module.moduleDescription.title) },
+        supportingContent = { Text(module.moduleDescription.description) },
         colors = ListItemDefaults.colors(containerColor = backgroundColor),
     )
 }


### PR DESCRIPTION
## Summary
- extend `ModuleDescription` with human-readable descriptions
- show module description text in modules list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b70d4b4083269bbe7e63403059e2