### PR TITLE
Fix duplicate Android namespace and constructor overload ambiguity

### DIFF
--- a/main-core/build.gradle.kts
+++ b/main-core/build.gradle.kts
@@ -72,7 +72,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.main.core"
     compileSdk = 35
 
     defaultConfig {

--- a/main-runtime-stub/build.gradle.kts
+++ b/main-runtime-stub/build.gradle.kts
@@ -48,7 +48,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.main.runtime.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/main-runtime/build.gradle.kts
+++ b/main-runtime/build.gradle.kts
@@ -75,7 +75,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.main.runtime"
     compileSdk = 35
 
     defaultConfig {

--- a/main-runtime/src/androidMain/AndroidManifest.xml
+++ b/main-runtime/src/androidMain/AndroidManifest.xml
@@ -2,7 +2,7 @@
 
     <application>
         <activity
-            android:name=".runtime.KickActivity"
+            android:name="ru.bartwell.kick.runtime.KickActivity"
             android:exported="false" />
     </application>
 </manifest>

--- a/module/firebase/firebase-analytics-stub/build.gradle.kts
+++ b/module/firebase/firebase-analytics-stub/build.gradle.kts
@@ -70,7 +70,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.firebaseanalytics.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/module/firebase/firebase-analytics/build.gradle.kts
+++ b/module/firebase/firebase-analytics/build.gradle.kts
@@ -75,7 +75,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.firebaseanalytics"
     compileSdk = 35
 
     defaultConfig {

--- a/module/firebase/firebase-cloud-messaging-stub/build.gradle.kts
+++ b/module/firebase/firebase-cloud-messaging-stub/build.gradle.kts
@@ -65,7 +65,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.fcm.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/module/firebase/firebase-cloud-messaging/build.gradle.kts
+++ b/module/firebase/firebase-cloud-messaging/build.gradle.kts
@@ -75,7 +75,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.fcm"
     compileSdk = 35
 
     defaultConfig {

--- a/module/logging/logging-stub/build.gradle.kts
+++ b/module/logging/logging-stub/build.gradle.kts
@@ -69,7 +69,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.logging.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/module/logging/logging/build.gradle.kts
+++ b/module/logging/logging/build.gradle.kts
@@ -100,7 +100,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.logging"
     compileSdk = 35
 
     defaultConfig {

--- a/module/logging/logging/src/androidMain/AndroidManifest.xml
+++ b/module/logging/logging/src/androidMain/AndroidManifest.xml
@@ -2,7 +2,7 @@
 
     <application>
         <provider
-            android:name=".module.logging.feature.table.util.KickFileProvider"
+            android:name="ru.bartwell.kick.module.logging.feature.table.util.KickFileProvider"
             android:authorities="${applicationId}.kickfileprovider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/module/network/ktor3-stub/build.gradle.kts
+++ b/module/network/ktor3-stub/build.gradle.kts
@@ -66,7 +66,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.ktor3.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/module/network/ktor3/build.gradle.kts
+++ b/module/network/ktor3/build.gradle.kts
@@ -107,7 +107,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.ktor3"
     compileSdk = 35
 
     defaultConfig {

--- a/module/settings/control-panel-stub/build.gradle.kts
+++ b/module/settings/control-panel-stub/build.gradle.kts
@@ -70,7 +70,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.controlpanel.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/module/settings/control-panel/build.gradle.kts
+++ b/module/settings/control-panel/build.gradle.kts
@@ -91,7 +91,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.controlpanel"
     compileSdk = 35
 
     defaultConfig {

--- a/module/settings/control-panel/src/iosTest/kotlin/ru/bartwell/kick/module/controlpanel/feature/main/presentation/ControlPanelIosUiTest.kt
+++ b/module/settings/control-panel/src/iosTest/kotlin/ru/bartwell/kick/module/controlpanel/feature/main/presentation/ControlPanelIosUiTest.kt
@@ -21,7 +21,7 @@ class ControlPanelIosUiTest {
     @Test
     fun interactions() = runComposeUiTest {
         val items = listOf(
-            ControlPanelItem("FeatureFlag", InputType.Boolean(false), null),
+            ControlPanelItem("FeatureFlag", InputType.Boolean(false)),
             ControlPanelItem("MaxItems", InputType.Int(5), Editor.InputNumber(min = 0.0, max = 100.0)),
             ControlPanelItem("Mode", InputType.String("A"), Editor.InputString(singleLine = true))
         )

--- a/module/settings/control-panel/src/jvmTest/kotlin/ru/bartwell/kick/module/controlpanel/feature/main/presentation/ControlPanelUiTest.kt
+++ b/module/settings/control-panel/src/jvmTest/kotlin/ru/bartwell/kick/module/controlpanel/feature/main/presentation/ControlPanelUiTest.kt
@@ -25,7 +25,7 @@ class ControlPanelUiTest {
     @Test
     fun back_and_save_and_toggle_and_number_and_string() {
         val items = listOf(
-            ControlPanelItem("FeatureFlag", InputType.Boolean(false), null),
+            ControlPanelItem("FeatureFlag", InputType.Boolean(false)),
             ControlPanelItem("MaxItems", InputType.Int(5), Editor.InputNumber(min = 0.0, max = 100.0)),
             ControlPanelItem("Mode", InputType.String("A"), Editor.InputString(singleLine = true))
         )

--- a/module/settings/multiplatform-settings-stub/build.gradle.kts
+++ b/module/settings/multiplatform-settings-stub/build.gradle.kts
@@ -70,7 +70,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.multiplatformsettings.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/module/settings/multiplatform-settings/build.gradle.kts
+++ b/module/settings/multiplatform-settings/build.gradle.kts
@@ -90,7 +90,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.multiplatformsettings"
     compileSdk = 35
 
     defaultConfig {

--- a/module/sqlite/sqlite-room-adapter-stub/build.gradle.kts
+++ b/module/sqlite/sqlite-room-adapter-stub/build.gradle.kts
@@ -45,7 +45,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick.adapter.room"
+    namespace = "ru.bartwell.kick.adapter.room.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/module/sqlite/sqlite-runtime-stub/build.gradle.kts
+++ b/module/sqlite/sqlite-runtime-stub/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.sqlite.runtime.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/module/sqlite/sqlite-runtime/build.gradle.kts
+++ b/module/sqlite/sqlite-runtime/build.gradle.kts
@@ -98,7 +98,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.sqlite.runtime"
     compileSdk = 35
 
     defaultConfig {

--- a/module/sqlite/sqlite-sqldelight-adapter-stub/build.gradle.kts
+++ b/module/sqlite/sqlite-sqldelight-adapter-stub/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.sqlite.sqldelight.stub"
     compileSdk = 35
 
     defaultConfig {

--- a/module/sqlite/sqlite-sqldelight-adapter/build.gradle.kts
+++ b/module/sqlite/sqlite-sqldelight-adapter/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
 }
 
 android {
-    namespace = "ru.bartwell.kick"
+    namespace = "ru.bartwell.kick.module.sqlite.sqldelight"
     compileSdk = 35
 
     defaultConfig {


### PR DESCRIPTION
Assign unique Android namespace to each module to resolve the 'namespace used in multiple modules' build error. Also fix ControlPanelItem constructor call ambiguity in iOS and JVM tests by dropping the redundant null argument.